### PR TITLE
chore: upgrade Gradle wrapper to 9.4.1 (Kotlin 2.x)

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -16,7 +16,7 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Upgrades the Gradle wrapper to 9.4.1.

Gradle 9.4.1 bundles Kotlin 2.0.x, resolving compatibility issues with `spotbugs-gradle-plugin 6.4.x` and other plugins compiled with Kotlin 2.x metadata.

This is part of the Kotlin 2.x upgrade across all creek-service repos.