### PR TITLE
fix: use GITHUB_TOKEN for GitHub Packages Dependabot auth

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,8 @@ registries:
     url: https://s01.oss.sonatype.org/content/repositories/snapshots/
   creek-github-packages:
     type: maven-repository
-    url: https://maven.pkg.github.com/creek-service/*
-    username: "Creek-Bot-Token"
+    url: https://maven.pkg.github.com/creek-service/
+    username: x-access-token
     password: "\u0067hp_LtyvXrQZen3WlKenUhv21Mg6NG38jn0AO2YH"
 updates:
   - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ registries:
     type: maven-repository
     url: https://maven.pkg.github.com/creek-service/
     username: x-access-token
-    password: "\u0067hp_LtyvXrQZen3WlKenUhv21Mg6NG38jn0AO2YH"
+    password: ${{secrets.GITHUB_TOKEN}}
 updates:
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Replace the hardcoded PAT with `${{secrets.GITHUB_TOKEN}}` which is automatically available to Dependabot for accessing GitHub Packages within the same organization.

Changes:
- `username`: `"Creek-Bot-Token"` → `x-access-token` (required by GitHub Packages)
- `password`: hardcoded PAT → `${{secrets.GITHUB_TOKEN}}` (auto-available to Dependabot in same org)
- `url`: removed trailing `*` (Dependabot uses prefix-matching, the wildcard is not needed)