### PR TITLE
fix: use CREEK_PACKAGES_TOKEN secret for GitHub Packages Dependabot auth

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ registries:
     type: maven-repository
     url: https://maven.pkg.github.com/creek-service/
     username: x-access-token
-    password: ${{secrets.GITHUB_TOKEN}}
+    password: ${{secrets.CREEK_PACKAGES_TOKEN}}
 updates:
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Fixes Dependabot authentication for GitHub Packages registry.

GITHUB_TOKEN is an invalid Dependabot secret name (names cannot start with GITHUB_). This PR replaces it with CREEK_PACKAGES_TOKEN, an org-level Dependabot secret with read:packages scope for the creek-service org.